### PR TITLE
Add minio client ARM64 installation step

### DIFF
--- a/source/includes/minio-mc-installation.rst
+++ b/source/includes/minio-mc-installation.rst
@@ -36,6 +36,20 @@
          export PATH=$PATH:$HOME/minio-binaries/
 
          mc --help
+         
+      **ARM64**
+
+      .. code-block:: shell
+         :class: copyable
+
+         curl https://dl.min.io/client/mc/release/linux-arm64/mc \
+           --create-dirs \
+           -o ~/minio-binaries/mc
+
+         chmod +x $HOME/minio-binaries/mc
+         export PATH=$PATH:$HOME/minio-binaries/
+
+         mc --help
 
    .. tab-item:: macOS
 


### PR DESCRIPTION
Reference the already published arm64 binary as more users are running on ARM64

https://github.com/minio/docs/issues/679